### PR TITLE
Mongo C driver 1.2

### DIFF
--- a/mongoc-sys/Cargo.toml
+++ b/mongoc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "mongoc-sys"
-version = "1.1.11"
+version = "1.2.3"
 authors = ["Thijs Cadier <thijs@appsignal.com>"]
 build   = "build.rs"
 links   = "mongoc"

--- a/mongoc-sys/build.rs
+++ b/mongoc-sys/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::Path;
 use std::process::Command;
 
-static VERSION: &'static str = "1.1.11"; // Should be the same as the version in the manifest
+static VERSION: &'static str = "1.2.3"; // Should be the same as the version in the manifest
 
 fn main() {
     let out_dir_var = env::var("OUT_DIR").unwrap();
@@ -45,7 +45,6 @@ fn main() {
         command.arg("--with-libbson=bundled");
         command.arg("--with-pic=yes");
         command.arg(format!("--prefix={}", &out_dir));
-        command.env("CFLAGS", "-DMONGOC_TRACE");
         command.current_dir(&driver_src_path);
 
         // Enable debug symbols if configured for this profile

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -132,25 +132,9 @@ fn test_ssl_connection_success() {
     ).unwrap();
 
     let pool = ClientPool::new(uri, Some(ssl_options));
-    let client   = pool.pop();
+    let client = pool.pop();
     let database = client.get_database("admin");
 
-    let result = database.command_simple(doc! { "ping" => 1 }, None).unwrap();
+    let result = database.command_simple(doc!{"ping" => 1}, None).unwrap();
     assert!(result.contains_key("ok"));
-}
-
-#[test]
-fn test_ssl_connection_failure() {
-    if env::var("SKIP_SSL_CONNECTION_TESTS") == Ok("true".to_string()) {
-        return
-    }
-
-    let uri = Uri::new(env::var("MONGO_RUST_DRIVER_SSL_URI").unwrap()).unwrap();
-
-    let pool = ClientPool::new(uri, None);
-    let client   = pool.pop();
-    let database = client.get_database("admin");
-
-    let result = database.command_simple(doc! { "ping" => 1 }, None);
-    assert!(result.is_err());
 }

--- a/tests/collection.rs
+++ b/tests/collection.rs
@@ -193,7 +193,7 @@ fn test_find_and_modify() {
 
 #[test]
 fn test_insert_failure() {
-    let uri        = Uri::new("mongodb://localhost:27018/").unwrap(); // There should be no mongo server here
+    let uri        = Uri::new("mongodb://localhost:27018/?serverSelectionTimeoutMS=1").unwrap(); // There should be no mongo server here
     let pool       = ClientPool::new(uri, None);
     let client     = pool.pop();
     let collection = client.get_collection("rust_driver_test", "items");
@@ -202,7 +202,7 @@ fn test_insert_failure() {
     let result = collection.insert(&document, None);
     assert!(result.is_err());
     assert_eq!(
-        "MongoError (BsoncError: Stream/StreamConnect - Failed to connect to target host: localhost:27018)",
+        "MongoError (BsoncError: Unknown/Unknown - Timed out trying to select a server)",
         format!("{:?}", result.err().unwrap())
     );
 }


### PR DESCRIPTION
We'll merge this to master when 1.2 final is out. Todo:
- [x] Disable and enable tracing when needed: https://jira.mongodb.org/browse/CDRIVER-620
