### PR TITLE
Use symver version requirements for dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ license       = "MIT/Apache-2.0"
 name = "tests"
 
 [dependencies]
-libc = "> 0.2.0"
-log  = "> 0.3.0"
-bson = "> 0.1.0"
+libc = "0.2"
+log  = "0.3"
+bson = "0.8"
 
 [dependencies.mongoc-sys]
 path    = "mongoc-sys"

--- a/mongoc-sys/Cargo.toml
+++ b/mongoc-sys/Cargo.toml
@@ -12,5 +12,5 @@ exclude = [
 ]
 
 [dependencies]
-libc        = "> 0.2.0"
-openssl-sys = "> 0.7.0"
+libc        = "0.2"
+openssl-sys = "0.9"


### PR DESCRIPTION
Using the inequality requirements can cause builds to break in dependent crates. Semver version requirements should be used instead.  For example if an a crate was dependent on both bson and mongo_driver and bson released a new semver incompatible version this could cause the dependent crate to break in one of two possible ways.  

The first possible way it could break is that the  dependent crate using as a semver compatibility requirement.  This would cause cargo to resolve the newest version for mongo_driver and the older, semver compatible version for the dependent crate.  Then any time bson objects are shared between the two the user will get an error like: 

note: expected type `&bson::ordered::OrderedDocument` (struct `bson::ordered::OrderedDocument`)
                found type `&bson::ordered::OrderedDocument` (struct `bson::ordered::OrderedDocument`)
note: Perhaps two different versions of crate `bson` are being used?

The other possible way it could break is if the dependent crate sets its dependency to bson using the same inequality.  This means that both the dependent crate and mongo_driver will also pick up the newest version of bson, but we don’t know if that version will still build.  Whatever the upstream breaking changes are could break either crate.