### PR TITLE
Added the ability to automatically manage getMore calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 mongoc-sys/mongo-c-driver*
 ssl_env_vars
 .idea/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 mongoc-sys/mongo-c-driver*
 ssl_env_vars
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ target
 Cargo.lock
 mongoc-sys/mongo-c-driver*
 ssl_env_vars
+
 .idea/
 .DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ name = "tests"
 libc = "^0.2"
 log  = "^0.3"
 bson = "^0.11"
+serde = "1.0"
+serde_derive = "1.0"
 
 [dependencies.mongoc-sys]
 path    = "mongoc-sys"

--- a/mongoc-sys/src/lib.rs
+++ b/mongoc-sys/src/lib.rs
@@ -102,6 +102,7 @@ pub mod bindings {
         pub fn mongoc_database_get_collection(database: *mut mongoc_database_t, name: *const ::libc::c_char) -> *mut mongoc_collection_t;
         pub fn mongoc_database_get_name(database: *mut mongoc_database_t) -> *const ::libc::c_char;
         pub fn mongoc_database_destroy(database: *mut mongoc_database_t) -> ();
+        pub fn mongoc_database_has_collection(database: *mut mongoc_database_t, name: *const ::libc::c_char, error: *mut bson_error_t) -> ::libc::boolean_t;
     }
 
     // Client

--- a/mongoc-sys/src/lib.rs
+++ b/mongoc-sys/src/lib.rs
@@ -102,7 +102,7 @@ pub mod bindings {
         pub fn mongoc_database_get_collection(database: *mut mongoc_database_t, name: *const ::libc::c_char) -> *mut mongoc_collection_t;
         pub fn mongoc_database_get_name(database: *mut mongoc_database_t) -> *const ::libc::c_char;
         pub fn mongoc_database_destroy(database: *mut mongoc_database_t) -> ();
-        pub fn mongoc_database_has_collection(database: *mut mongoc_database_t, name: *const ::libc::c_char, error: *mut bson_error_t) -> ::libc::boolean_t;
+        pub fn mongoc_database_has_collection(database: *mut mongoc_database_t, name: *const ::libc::c_char, error: *mut bson_error_t) -> ::libc::int32_t;
     }
 
     // Client

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -4,9 +4,10 @@ use std::iter::Iterator;
 use std::ptr;
 use std::thread;
 use std::time::Duration;
+use std::collections::VecDeque;
 
 use mongoc::bindings;
-use bson::{Bson,Document,oid};
+use bson::{self,Bson,Document,oid};
 
 use super::BsoncError;
 use super::bsonc;
@@ -15,6 +16,7 @@ use super::database::Database;
 use super::flags::QueryFlag;
 use super::collection::{Collection,TailOptions};
 use super::CommandAndFindOptions;
+use super::MongoError::ValueAccessError;
 
 use super::Result;
 
@@ -250,4 +252,122 @@ impl<'a> Iterator for TailingCursor<'a> {
             self.cursor      = None;
         }
     }
+}
+
+type DocArray = VecDeque<Document>;
+type CursorId = i64;
+
+pub struct BatchCursor<'a> {
+    cursor:     Cursor<'a>,
+    db:         &'a Database<'a>,
+    coll_name:  String,
+    cursor_id:  Option<CursorId>,
+    documents:  Option<DocArray>
+
+}
+
+impl<'a> BatchCursor<'a> {
+    pub fn new(
+        cursor: Cursor<'a>,
+        db: &'a Database<'a>,
+        coll_name: String
+    ) -> BatchCursor<'a> {
+        BatchCursor {
+            cursor,
+            db,
+            coll_name,
+            cursor_id: None,
+            documents: None
+        }
+    }
+
+    fn get_cursor_next(&mut self) -> Option<Result<Document>> {
+        let item_opt = self.cursor.next();
+        if let Some(item_res) = item_opt {
+            if let Ok(item) = item_res {
+                let docs_ret = batch_to_array(item);
+                if let Ok(docs) = docs_ret {
+                    self.documents = docs.0;
+                    if docs.1.is_some() {self.cursor_id = docs.1}
+                    let res = self.get_next_doc();
+                    if res.is_some() { return res; }
+                } else {
+                    return Some(Err(docs_ret.err().unwrap()));
+                }
+            }
+        }
+        None
+    }
+
+    fn get_next_doc(&mut self) -> Option<Result<Document>> {
+        if let Some(ref mut docs) = self.documents {
+            if docs.len() > 0 {
+                let doc = docs.pop_front().unwrap();
+                return Some(Ok(doc));
+            }
+        }
+        None
+    }
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct CommandSimpleBatch {
+    id: CursorId,
+    first_batch: Option<DocArray>,
+    next_batch: Option<DocArray>
+}
+#[derive(Deserialize, Debug)]
+struct CommandSimpleResult {
+    cursor: CommandSimpleBatch
+}
+
+fn batch_to_array(doc: Document) -> Result<(Option<DocArray>,Option<CursorId>)> {
+    let doc_result: Result<CommandSimpleResult> =
+        bson::from_bson(Bson::Document(doc.clone()))
+            .map_err(|err|
+                {
+                    error!("cannot read batch from db: {}", err);
+                    ValueAccessError(bson::ValueAccessError::NotPresent)
+                });
+
+    trace!("input: {}, result: {:?}", doc, doc_result);
+
+    doc_result.map(|v| {
+        if v.cursor.first_batch.is_some() {return (v.cursor.first_batch, Some(v.cursor.id));}
+        if v.cursor.next_batch.is_some() {return (v.cursor.next_batch, Some(v.cursor.id));}
+        (None,None)
+    })
+}
+
+impl<'a> Iterator for BatchCursor<'a> {
+    type Item = Result<Document>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+
+        // (1) try the local document buffer
+        let res = self.get_next_doc();
+        if res.is_some() {return res;}
+
+        // (2) try next()
+        let res = self.get_cursor_next();
+        if res.is_some() {return res;}
+
+        // (3) try getMore
+        if let Some(cid) = self.cursor_id {
+            let command = doc! {
+                "getMore": cid as i64,
+                "collection": self.coll_name.clone()
+                };
+            let cur_result = self.db.command(command, None);
+            if let Ok(cur) = cur_result {
+                self.cursor = cur;
+                let res = self.get_cursor_next();
+                if res.is_some() { return res; }
+            }
+        }
+        None
+    }
+
+
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -48,6 +48,8 @@ impl<'a> Database<'a> {
 
     /// Execute a command on the database.
     /// This is performed lazily and therefore requires calling `next` on the resulting cursor.
+    /// Results are returned in batches as per the mongoc driver.
+    /// To get the next batch: https://docs.mongodb.com/manual/reference/command/getMore/
     pub fn command(
         &'a self,
         command: Document,

--- a/src/database.rs
+++ b/src/database.rs
@@ -28,7 +28,7 @@ pub enum CreatedBy<'a> {
 
 #[doc(hidden)]
 fn get_coll_name_from_doc(doc: &Document) -> Result<String> {
-    const VALID_COMMANDS: &'static [&'static str] = &["find", "aggregate"];
+    const VALID_COMMANDS: &'static [&'static str] = &["find", "aggregate", "listIndexes"];
     for s in VALID_COMMANDS {
         if let Ok(val) = doc.get_str(s) {
             return Ok(val.to_owned())

--- a/src/database.rs
+++ b/src/database.rs
@@ -189,6 +189,31 @@ impl<'a> Database<'a> {
         };
         String::from_utf8_lossy(cstr.to_bytes())
     }
+
+    /// Create a new collection in this database.
+    pub fn has_collection<S: Into<Vec<u8>>>(
+        &self,
+        name:    S
+    ) -> Result<bool> {
+        let mut error = BsoncError::empty();
+        let name_cstring = CString::new(name).unwrap();
+
+        let has_collection = unsafe {
+            bindings::mongoc_database_has_collection(
+                self.inner,
+                name_cstring.as_ptr(),
+                error.mut_inner())
+        };
+
+        if error.is_empty() {
+            Ok(match has_collection{
+                0 => false,
+                _ => true
+            })
+        } else {
+            Err(error.into())
+        }
+    }
 }
 
 impl<'a> Drop for Database<'a> {

--- a/src/database.rs
+++ b/src/database.rs
@@ -26,7 +26,6 @@ pub enum CreatedBy<'a> {
     OwnedClient(Client<'a>)
 }
 
-#[doc(hidden)]
 fn get_coll_name_from_doc(doc: &Document) -> Result<String> {
     const VALID_COMMANDS: &'static [&'static str] = &["find", "aggregate", "listIndexes"];
     for s in VALID_COMMANDS {
@@ -60,8 +59,8 @@ impl<'a> Database<'a> {
 
     /// Execute a command on the database.
     /// This is performed lazily and therefore requires calling `next` on the resulting cursor.
-    /// Results are returned in batches as per the mongoc driver.
-    /// To get the next batch: https://docs.mongodb.com/manual/reference/command/getMore/
+    /// if your are using a command like find or aggregate `command_batch` is likely
+    /// more convenient for you.
     pub fn command(
         &'a self,
         command: Document,
@@ -103,7 +102,7 @@ impl<'a> Database<'a> {
         ))
     }
 
-    /// Execute a command on the database.
+    /// Execute a command on the database and returns a `BatchCursor`
     /// Automates the process of getting the next batch from getMore
     /// and parses the batch so only the result documents are returned.
     /// I am unsure of the best practices of when to use this or the CRUD function.
@@ -221,7 +220,7 @@ impl<'a> Database<'a> {
         String::from_utf8_lossy(cstr.to_bytes())
     }
 
-    /// Create a new collection in this database.
+    /// This function checks to see if a collection exists on the MongoDB server within database.
     pub fn has_collection<S: Into<Vec<u8>>>(
         &self,
         name:    S

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@ extern crate log;
 extern crate serde_derive;
 extern crate serde;
 
-
 use std::ffi::CStr;
 use std::ptr;
 use std::result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,11 @@ extern crate bson;
 #[macro_use]
 extern crate log;
 
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+
+
 use std::ffi::CStr;
 use std::ptr;
 use std::result;

--- a/tests/database.rs
+++ b/tests/database.rs
@@ -63,11 +63,15 @@ fn test_has_collection() {
     let database = client.get_database("rust_test");
     database.get_collection("created_collection").drop().unwrap_or(());
 
+    const COLL_NAME: &'static str = "created_collection";
+
     let collection = database.create_collection(
-        "created_collection",
+        COLL_NAME,
         None
     ).unwrap();
 
-    assert_eq!("created_collection", collection.get_name().to_mut());
-    assert!(database.has_collection("created_collection").unwrap());
+    assert_eq!(COLL_NAME, collection.get_name().to_mut());
+    assert!(database.has_collection(COLL_NAME).unwrap());
+
+    database.command_simple(doc!{ "drop": COLL_NAME}, None).unwrap();
 }

--- a/tests/database.rs
+++ b/tests/database.rs
@@ -61,9 +61,10 @@ fn test_has_collection() {
     let pool     = ClientPool::new(uri, None);
     let client   = pool.pop();
     let database = client.get_database("rust_test");
-    database.get_collection("created_collection").drop().unwrap_or(());
 
-    const COLL_NAME: &'static str = "created_collection";
+    const COLL_NAME: &'static str = "created_collection2";
+
+    database.get_collection(COLL_NAME).drop().unwrap_or(());
 
     let collection = database.create_collection(
         COLL_NAME,
@@ -72,6 +73,4 @@ fn test_has_collection() {
 
     assert_eq!(COLL_NAME, collection.get_name().to_mut());
     assert!(database.has_collection(COLL_NAME).unwrap());
-
-    database.command_simple(doc!{ "drop": COLL_NAME}, None).unwrap();
 }

--- a/tests/database.rs
+++ b/tests/database.rs
@@ -54,3 +54,20 @@ fn test_create_collection() {
 
     assert_eq!("created_collection", collection.get_name().to_mut());
 }
+
+#[test]
+fn test_has_collection() {
+    let uri      = Uri::new("mongodb://localhost:27017/").unwrap();
+    let pool     = ClientPool::new(uri, None);
+    let client   = pool.pop();
+    let database = client.get_database("rust_test");
+    database.get_collection("created_collection").drop().unwrap_or(());
+
+    let collection = database.create_collection(
+        "created_collection",
+        None
+    ).unwrap();
+
+    assert_eq!("created_collection", collection.get_name().to_mut());
+    assert!(database.has_collection("created_collection").unwrap());
+}


### PR DESCRIPTION
When using command with find and append you need to call getMore which can be messy.  calling database.command_batch allows you to run:
```rust
        let cur = database.command_batch(doc!{"find":TEST_COLLECTION_NAME},None);
        let mut count = 0;
        for doc in cur.unwrap() {
            count += 1;
            println!("doc: {:?}", doc );
        }
```

also added db.has_collection and other minor changes