### PR TITLE
Attempt to update to libmongoc 1.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ brew install openssl@1.1
 Export these env vars the before you make a clean build:
 
 ```
-export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
-export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+export LDFLAGS="-L/usr/local/opt/openssl/lib"
+export CPPFLAGS="-I/usr/local/opt/openssl/include"
 ```
 
 ## Logging

--- a/mongoc-sys/Cargo.toml
+++ b/mongoc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mongoc-sys"
-version     = "1.8.2-1"
+version     = "1.13.1"
 description = "Sys package with installer and bindings for mongoc"
 authors     = ["Thijs Cadier <thijs@appsignal.com>"]
 build       = "build.rs"


### PR DESCRIPTION
This is currently failing with:

```
   Compiling mongoc-sys v1.13.1 (file:///Users/thijs/opensource/mongo-rust-driver/mongoc-sys)
error: could not find native static library `bson-1.0`, perhaps an -L flag is missing?

error: aborting due to previous error

error: Could not compile `mongoc-sys`.
```