### PR TITLE
Add env export for PKG_CONFIG_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Export these env vars the before you make a clean build:
 ```
 export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
 export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
 ```
 
 ## Logging


### PR DESCRIPTION
This was needed in order to successfully build crate `mongoc-sys`, which `mongo_driver` v0.12 depends on.