### PR TITLE
Make driver architecture agnostic

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,7 +4,7 @@ name: Mongo Rust Driver tests
 agent:
   machine:
     type: e1-standard-8
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 # Cancel all running and queued workflows before this one
 auto_cancel:

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use core::ffi::c_char;
 use std::error;
 use std::fmt;
 use std::borrow::Cow;
@@ -236,7 +237,7 @@ impl BsoncError {
 
     /// The error's message.
     pub fn get_message(&self) -> Cow<str> {
-        let cstr = unsafe { CStr::from_ptr(&self.inner.message as *const i8) };
+        let cstr = unsafe { CStr::from_ptr(&self.inner.message as *const c_char) };
         String::from_utf8_lossy(cstr.to_bytes())
     }
 


### PR DESCRIPTION
This PR makes the mongo-rust-driver architecture agnostic by fixing a type cast that was platform-specific.

The c_char type varies by architecture:
- On x86_64: c_char is i8
- On ARM (aarch64): c_char is u8

Using i8 directly caused compilation failures on ARM platforms. Using c_char from core::ffi ensures the correct type is used regardless of the target architecture.